### PR TITLE
Don't use a named volume for logs to solve Windows startup issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,5 @@
-version: '3'
+version: "3"
 volumes:
-  logs:
-    driver: local
-    driver_opts:
-      type: none
-      device: "${SWA_HOST_LOG_DIR}"
-      o: bind
   dummy:
     driver: local
 
@@ -16,12 +10,13 @@ services:
     environment:
       TOMCAT_OPTS: "-Xms${SWA_CORE_SERVICE_JAVA_HEAP_MIN:-512m} -Xmx${SWA_CORE_SERVICE_JAVA_HEAP_MAX:-2048m} -XX:+UseContainerSupport -server -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom"
       SWA_PRECONDITION_SERVICES: "tcp:script-engine:8081"
-      CATALINA_OPTS: "-Deffektif.javascript.server.url=http://script-engine:8081 \
+      CATALINA_OPTS:
+        "-Deffektif.javascript.server.url=http://script-engine:8081 \
         -Deffektif.license.location=/config \
         -Dlogback.configurationFile=/workflow/logback.xml \
         -Deffektif.google.secrets.location=/config/google_drive_client_secrets.json"
     volumes:
-      - logs:/usr/share/tomcat/logs
+      - ${SWA_HOST_LOG_DIR}:/usr/share/tomcat/logs
       - ${SWA_CORE_SERVICE_HOST_CONFIG_DIR}:/config
       - ${SWA_CONFIG_PROVIDER_DIR:-dummy}:/swa_lib
     depends_on:
@@ -45,7 +40,7 @@ services:
       SE_LOG_SIZE: 20000
       ELK_LOG_ENABLED: "false"
     volumes:
-      - logs:/workflow/logs
+      - ${SWA_HOST_LOG_DIR}:/workflow/logs
     restart: on-failure
 
   mail-relay:
@@ -57,7 +52,7 @@ services:
     ports:
       - "0.0.0.0:${SWA_MAIL_RELAY_PORT:-25}:25"
     volumes:
-      - logs:/workflow/logs
+      - ${SWA_HOST_LOG_DIR}:/workflow/logs
     restart: on-failure
 
   public-api:
@@ -68,7 +63,7 @@ services:
       CRNK_DOMAIN_NAME: "${SWA_CORE_SERVICE_BASEURL}"
       LOG_FILE: "/workflow/logs/public-api.log"
     volumes:
-      - logs:/workflow/logs
+      - ${SWA_HOST_LOG_DIR}:/workflow/logs
     restart: on-failure
 
   https-proxy:


### PR DESCRIPTION
I removed the named logs volume which caused trouble on `docker-compose up` with Windows and added direct bindings to the single services.

Please test again on Linux if it works.