### PR TITLE
signavio/workflow-deploy-tools#141 - added rotation for log files in on prem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
     depends_on:
       - script-engine
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   script-engine:
     image: "signavio-on-premise.jfrog.io/swa/script-engine:v3.139.1"
@@ -39,6 +44,11 @@ services:
     volumes:
       - ${SWA_HOST_LOG_DIR:-./logs}:/workflow/logs
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   mail-relay:
     image: "signavio-on-premise.jfrog.io/swa/${SWA_MAIL_RELAY_IMG:-mail-relay:v3.0.2}"
@@ -51,6 +61,11 @@ services:
     volumes:
       - ${SWA_HOST_LOG_DIR:-./logs}:/workflow/logs
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   public-api:
     image: "signavio-on-premise.jfrog.io/swa/${SWA_PUBLIC_API_IMG:-public-api:v0.0.2}"
@@ -63,6 +78,11 @@ services:
     volumes:
       - ${SWA_HOST_LOG_DIR:-./logs}:/workflow/logs
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   https-proxy:
     image: "signavio-on-premise.jfrog.io/swa/https-proxy:v2.1.0"
@@ -82,3 +102,8 @@ services:
     depends_on:
       - core-service
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"


### PR DESCRIPTION
Part of #https://github.com/signavio/workflow-deploy-tools/issues/141

Added log roation for all services.
The config is set to `50m` file size and `5` files at max.

*Not for testsession*:
How to test:

1) The best way to test it is to modify the file size max to ´1m` for the script engine
2) Set log level for script engine to debug (for output = better)
3) Start the system
4) Create a case with a script task and log a lot of stuff [or import this workflow](https://github.com/signavio/workflow-deploy-tools/files/5208481/abc.zip)
5. Start a few cases

**Expected:**
Find the docker container and check the the logs are rotation as shown in the screenshot below

![image](https://user-images.githubusercontent.com/13994768/92917236-9729e680-f42e-11ea-9501-0f041505625f.png)

